### PR TITLE
fix: key exchange round II

### DIFF
--- a/Flow.Launcher.Plugin.KeePass2Flow/Flow.Launcher.Plugin.KeePass2Flow.csproj
+++ b/Flow.Launcher.Plugin.KeePass2Flow/Flow.Launcher.Plugin.KeePass2Flow.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net7.0-windows</TargetFramework>
     <AssemblyName>Flow.Launcher.Plugin.KeePass2Flow</AssemblyName>
     <PackageId>Flow.Launcher.Plugin.KeePass2Flow</PackageId>
-    <Authors>geisterfurz007</Authors>
-    <PackageProjectUrl>https://github.com/geisterfurz007/KeePass2Flow</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/geisterfurz007/KeePass2Flow</RepositoryUrl>
+    <Authors>mvarendorff</Authors>
+    <PackageProjectUrl>https://github.com/mvarendorff/KeePass2Flow</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/mvarendorff/KeePass2Flow</RepositoryUrl>
     <PackageTags>flow-launcher flow-plugin</PackageTags>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Flow.Launcher.Plugin.KeePass2Flow/Flow.Launcher.Plugin.KeePass2Flow.csproj
+++ b/Flow.Launcher.Plugin.KeePass2Flow/Flow.Launcher.Plugin.KeePass2Flow.csproj
@@ -46,4 +46,10 @@
     </Page>
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <OutputPath>$(AppData)\FlowLauncher\Plugins\KeePass2Flow</OutputPath>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+    <PreBuildEvent>taskkill /f /fi &quot;IMAGENAME eq Flow.Launcher.exe&quot;</PreBuildEvent>
+    <PostBuildEvent>start &quot;&quot; /d $(LocalAppData)\FlowLauncher\ Flow.Launcher.exe</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Flow.Launcher.Plugin.KeePass2Flow/Main.cs
+++ b/Flow.Launcher.Plugin.KeePass2Flow/Main.cs
@@ -98,20 +98,6 @@ public class KeePass2Flow : IAsyncPlugin, ISettingProvider, IAsyncDisposable
                 },
                 Score = 0,
             },
-            new ()
-            {
-                Title = "reconnect",
-                SubTitle = "Reconnect to KeePassRPC",
-                AutoCompleteText = $"{_context.CurrentPluginMetadata.ActionKeyword} reconnect ",
-                AsyncAction = async _ =>
-                {
-                    await _keePass2Client.Disconnect();
-                    TryInit(null);
-
-                    return false;
-                },
-                Score = 0,
-            },
             # endif
         };
 
@@ -129,6 +115,23 @@ public class KeePass2Flow : IAsyncPlugin, ISettingProvider, IAsyncDisposable
                 },
                 Score = 0,
             });
+
+            results.Add(
+                new ()
+                {
+                    Title = "reconnect",
+                    SubTitle = "Reset connection to KeePassRPC",
+                    AutoCompleteText = $"{_context.CurrentPluginMetadata.ActionKeyword} reconnect ",
+                    AsyncAction = async _ =>
+                    {
+                        await _keePass2Client.Disconnect();
+                        TryInit(null);
+
+                        return false;
+                    },
+                    Score = 0,
+                }
+            );
         }
 
         if (query.FirstSearch?.ToLower() == "auth" && _passwordFromFlowProvider.RequestInProgress)

--- a/Flow.Launcher.Plugin.KeePass2Flow/Main.cs
+++ b/Flow.Launcher.Plugin.KeePass2Flow/Main.cs
@@ -117,7 +117,7 @@ public class KeePass2Flow : IAsyncPlugin, ISettingProvider, IAsyncDisposable
             });
 
             results.Add(
-                new ()
+                new()
                 {
                     Title = "reconnect",
                     SubTitle = "Reset connection to KeePassRPC",

--- a/Flow.Launcher.Plugin.KeePass2Flow/plugin.json
+++ b/Flow.Launcher.Plugin.KeePass2Flow/plugin.json
@@ -3,10 +3,10 @@
     "ActionKeyword": "kp",
     "Name": "KeePass2Flow",
     "Description": "Hook up Flow to KeePass 2",
-    "Author": "geisterfurz007",
+    "Author": "mvarendorff",
     "Version": "1.1.3",
     "Language": "csharp",
-    "Website": "https://github.com/geisterfurz007/KeePass2Flow",
+    "Website": "https://github.com/mvarendorff/KeePass2Flow",
     "IcoPath": "icon.png",
     "ExecuteFileName": "Flow.Launcher.Plugin.KeePass2Flow.dll"
 }

--- a/Flow.Launcher.Plugin.KeePass2Flow/plugin.json
+++ b/Flow.Launcher.Plugin.KeePass2Flow/plugin.json
@@ -4,7 +4,7 @@
     "Name": "KeePass2Flow",
     "Description": "Hook up Flow to KeePass 2",
     "Author": "mvarendorff",
-    "Version": "1.1.3",
+    "Version": "1.1.4",
     "Language": "csharp",
     "Website": "https://github.com/mvarendorff/KeePass2Flow",
     "IcoPath": "icon.png",

--- a/KeePass2Client/Setup/KeePassSrp.cs
+++ b/KeePass2Client/Setup/KeePassSrp.cs
@@ -110,7 +110,7 @@ public class KeePassSrp
 
     public string GetKey()
     {
-        return Utils.Hash(S!.Value.ToString("X"));
+        return Utils.Hash(S!.Value.ToString("X").TrimStart('0'));
     }
 
     public void Reset()


### PR DESCRIPTION
## Features

- `kp reconnect` allows establishing a new key between the plugin and KeePassRPC
- The session is dropped automatically when decrypting a message fails

## Bugfixes

- In some instances, the key would not be identical between KeePassRPC and the plugin due to a missing trim

## Maintenance

- Updated author to new GitHub username
- Improved DX by terminating FlowLauncher before the build and restarting after
